### PR TITLE
feat: use level uid instead of extracting author name from uid as level identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Open the logger config file (`Zeepkist/BepInEx/config/net.tnrd.zeepkist.leaderbo
 
 ```conf
 [Formatting]
-Filename = %Date:yyyyMMddTHHmmss%_%LevelUid%_%Name%.csv
+Filename = %Date:yyyyMMddTHHmmss%_%LevelUid%_Xw==_%Name%.csv
 Entry = %SteamId%,%Username%,%Time%,%ZeepkistId%,%ColorId%,%HatId%
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ One or more CSV leaderboard logs in the `input` folder
 
 ```text
 Input Folder
- ├── 20221204T180734_18112022-104248521-AuthorName-481758454581-1683_RoomName.csv
+ ├── 20221204T180734_18112022-104248521-AuthorName-481758454581-1683_Xw==_RoomName.csv
  ├── 2021-01-01T12:00:00_1234567890_Example Level 2.csv
  └── 2021-01-01T12:00:00_1234567890_Example Level 3.csv
 ```
@@ -84,9 +84,9 @@ One or more folders in the `input` folder each containing one or more CSV leader
 ```text
 Input Folder
    ├── Example Event 1
-   │   └── 20221204T180734_18112022-104248521-AuthorName-481758454581-1683_RoomName.csv
+   │   └── 20221204T180734_18112022-104248521-AuthorName-481758454581-1683_Xw==_RoomName.csv
    └── Example Event 2
-      └── 20221204T180734_18112022-104248521-AuthorName-481758454581-1683_RoomName.csv
+      └── 20221204T180734_18112022-104248521-AuthorName-481758454581-1683_Xw==_RoomName.csv
 ```
 
 ### Multiple Seasons
@@ -97,14 +97,14 @@ One or more folders in the `input` folder each containing one or more events (se
 Input Folder
    ├── Season 1
    │   ├── Example Event 1
-   │   │   └── 20221204T180734_18112022-104248521-AuthorName-481758454581-1683_RoomName.csv
+   │   │   └── 20221204T180734_18112022-104248521-AuthorName-481758454581-1683_Xw==_RoomName.csv
    │   └── Example Event 2
-   │      └── 20221204T180734_18112022-104248521-AuthorName-481758454581-1683_RoomName.csv
+   │      └── 20221204T180734_18112022-104248521-AuthorName-481758454581-1683_Xw==_RoomName.csv
    └── Season 2
       ├── Example Event 1
-      │   └── 20221204T180734_18112022-104248521-AuthorName-481758454581-1683_RoomName.csv
+      │   └── 20221204T180734_18112022-104248521-AuthorName-481758454581-1683_Xw==_RoomName.csv
       └── Example Event 2
-         └── 20221204T180734_18112022-104248521-AuthorName-481758454581-1683_RoomName.csv
+         └── 20221204T180734_18112022-104248521-AuthorName-481758454581-1683_Xw==_RoomName.csv
 ```
 
 ## Output File Structure

--- a/src/utils/handleEvent.ts
+++ b/src/utils/handleEvent.ts
@@ -27,5 +27,7 @@ export const handleEvent = (path: string, metadata: Metadata) => {
     })
   }
 
+  console.log(`Finished processing ${path}`)
+
   return { levels, users }
 }

--- a/src/utils/handleLeaderboard.ts
+++ b/src/utils/handleLeaderboard.ts
@@ -20,7 +20,7 @@ export const handleLeaderboard = ({
 }: Properties) => {
   // `uid` is the unique id of the level played. End of the UID is indicated by '_Xw==_' in the file name
   const uid = file.slice(16).split('_Xw==_')[0]
-  console.log(`uid: ${uid}`)
+  console.log(`Processing ${uid}`)
 
   const fileData = readFileSync(`${path}/${file}`, 'utf8')
   const records: RawRecord[] = parse(fileData, {

--- a/src/utils/handleLeaderboard.ts
+++ b/src/utils/handleLeaderboard.ts
@@ -18,8 +18,9 @@ export const handleLeaderboard = ({
   path,
   file
 }: Properties) => {
-  // `name` is the author of the level played
-  const name = file.slice(35).split('-')[0]
+  // `uid` is the unique id of the level played. End of the UID is indicated by '_Xw==_' in the file name
+  const uid = file.slice(16).split('_Xw==_')[0]
+  console.log(`uid: ${uid}`)
 
   const fileData = readFileSync(`${path}/${file}`, 'utf8')
   const records: RawRecord[] = parse(fileData, {
@@ -35,14 +36,14 @@ export const handleLeaderboard = ({
       totalPoints: 0
     })
 
-    const level = levels.get(name)
+    const level = levels.get(uid)
     if (level) {
       level.push({
         steamId: record.SteamId,
         time: Number(record.Time)
       })
     } else {
-      levels.set(name, [
+      levels.set(uid, [
         {
           steamId: record.SteamId,
           time: Number(record.Time)


### PR DESCRIPTION
BREAKING CHANGE: You must update the configuration in net.tnrd.zeepkist.leaderboardlogger.cfg to match the version in the README